### PR TITLE
Hack fix: comment out one handler for sundata_parser.rb

### DIFF
--- a/sundata_parser.rb
+++ b/sundata_parser.rb
@@ -190,7 +190,7 @@ class SundataParser
     argument_values << "-h" if argument_values.empty?
     optparser = OptionParser.new do |opts|
       opts.banner = "Usage: sundata_parser.rb --outfile OUTPUT_FILENAME --fields FIELDS INPUT_FILE..."
-      opts.on "-oOUTFILE", "--outfile OUTFILE", "The name of the file output will be written to" do |outfile|
+      opts.on "-oOUTFILE", "--outfile OUTFILE", "Required. The name of the file output will be written to" do |outfile|
         @outfile = outfile
       end
       opts.on "-fFIELDS", "--fields FIELDS", "A comma-separated list of fields to output" do |fields|
@@ -199,6 +199,7 @@ class SundataParser
 
       opts.on "-h", "--help", "Prints this help" do
         puts opts
+        puts "    INPUT_FILES...                   Required. The text files containing SunData information."
         puts "  for more information and help visit https://github.com/nuclearsandwich/sundata-parser"
         exit
       end
@@ -210,7 +211,7 @@ class SundataParser
     end
 
     unless defined?(@outfile)
-      puts "Error: no output file. Run `#{$0} -h` for more information."
+      puts "Error: no output file, specify one with the --outfile option. Run `#{$0} -h` for more information."
       exit(1)
     end
 

--- a/sundata_parser.rb
+++ b/sundata_parser.rb
@@ -187,7 +187,7 @@ class SundataParser
   # this class method can take the preprocess_block directly.
   def SundataParser.run! argument_values, &preprocess_block
     require "optparse"
-    argument_values << "-h" if argument_values.empty?
+#    argument_values << "-h" if argument_values.empty?
     optparser = OptionParser.new do |opts|
       opts.banner = "Usage: sundata_parser.rb --outfile OUTPUT_FILENAME --fields FIELDS INPUT_FILE..."
       opts.on "-oOUTFILE", "--outfile OUTFILE", "The name of the file output will be written to" do |outfile|

--- a/sundata_parser.rb
+++ b/sundata_parser.rb
@@ -187,7 +187,10 @@ class SundataParser
   # this class method can take the preprocess_block directly.
   def SundataParser.run! argument_values, &preprocess_block
     require "optparse"
-#    argument_values << "-h" if argument_values.empty?
+    # If the program is run with no arguments, assume the user wants help.
+    # This is distinct from the later check which happens after options are parsed out and
+    # only the input files remain in the argument list.
+    argument_values << "-h" if argument_values.empty?
     optparser = OptionParser.new do |opts|
       opts.banner = "Usage: sundata_parser.rb --outfile OUTPUT_FILENAME --fields FIELDS INPUT_FILE..."
       opts.on "-oOUTFILE", "--outfile OUTFILE", "Required. The name of the file output will be written to" do |outfile|


### PR DESCRIPTION
The code has two places where "argument_values.empty?" is handled:

line 190 and line 207.

The code in and around 207 seems intended, it is the better way to handle the use case.

Q: If we were to keep the code in 207, would the _location_ of this code be better in 190?
